### PR TITLE
A couple small lockserver client improvements.

### DIFF
--- a/lockserver/client.cc
+++ b/lockserver/client.cc
@@ -30,6 +30,17 @@
 
 #include "lockserver/client.h"
 
+namespace {
+
+void
+usage()
+{
+    printf("Unknown command.. Try again!\n");
+    printf("Usage: exit | q | lock <key> | unlock <key>\n");
+}
+
+} // namespace
+
 int
 main(int argc, char **argv)
 {
@@ -68,14 +79,18 @@ main(int argc, char **argv)
             cmd[clen++] = c;
         cmd[clen] = '\0';
 
-        if (clen == 0) continue;
         tok = strtok(cmd, " ,.-");
+        if (tok == NULL) continue;
 
         if (strcasecmp(tok, "exit") == 0 || strcasecmp(tok, "q") == 0) {
             printf("Exiting..\n");
             break;
         } else if (strcasecmp(tok, "lock") == 0) {
             tok = strtok(NULL, " ,.-");
+            if (tok == NULL) {
+                usage();
+                continue;
+            }
             key = string(tok);
             status = locker.lock(key);
 
@@ -86,11 +101,15 @@ main(int argc, char **argv)
             }
         } else if (strcasecmp(tok, "unlock") == 0) {
             tok = strtok(NULL, " ,.-");
+            if (tok == NULL) {
+                usage();
+                continue;
+            }
             key = string(tok);
             locker.unlock(key);
             printf("Unlock Successful\n");
         } else {
-            printf("Unknown command.. Try again!\n");
+            usage();
         }
         fflush(stdout);
     }


### PR DESCRIPTION
1. Previously, typing ` `, `lock`, or `unlock` into a lockserver client's REPL would cause the client to crash because of some `strtok` calls that were returning `NULL`. Now, this bug is fixed; `strtok` returns are checked to be `NULL`, and no input should crash the client.
2. Previously, typing in an unrecognized command into the lockserver client's REPL would print `Unknown command.. Try again!`. Now, it also prints out the set of legal commands `Usage: exit | q | lock <key> | unlock <key>`. This makes it a bit easier for someone tinkering around with TAPIR for the first time (like me) to know what to type.