### PR TITLE
fix build on modern Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ EXPAND = lib/tmpl/expand
 
 CFLAGS := -g -Wall -pthread -iquote.obj/gen -Wno-uninitialized -O2 -DNASSERT
 #CFLAGS := -g -Wall -pthread -iquote.obj/gen -Wno-uninitialized 
-CXXFLAGS := -g -std=c++0x
+CXXFLAGS := -g
 LDFLAGS := -levent_pthreads
 ## Debian package: check
 #CHECK_CFLAGS := $(shell pkg-config --cflags check)

--- a/lockserver/Rules.mk
+++ b/lockserver/Rules.mk
@@ -27,8 +27,7 @@ $(d)lockserver-repl: $(o)lockserver-repl.o \
 	$(OBJS-ir-client) \
 	$(LIB-configuration) \
 	$(LIB-repltransport) \
-   	$(LIB-store-common) \
-	$(GTEST_MAIN)
+   	$(LIB-store-common)
 
 BINS += $(d)server-main $(d)client-main $(d)lockserver-repl
 

--- a/store/common/tracer.h
+++ b/store/common/tracer.h
@@ -12,6 +12,7 @@
 #include <sys/time.h>
 #include <map>
 #include <string>
+#include <cstdint>
 
 /* Trace details of an individual type of request. */
 typedef struct Request_Trace


### PR DESCRIPTION
These minor changes makes TAPIR build on current Arch Linux (`make` now works).